### PR TITLE
Move all import statements to the top

### DIFF
--- a/notebook-example/notebook-example.ipynb
+++ b/notebook-example/notebook-example.ipynb
@@ -72,7 +72,13 @@
     "from datetime import datetime\n",
     "from sklearn.ensemble import RandomForestClassifier\n",
     "from sklearn.model_selection import train_test_split\n",
-    "from sklearn.preprocessing import LabelEncoder"
+    "from sklearn.preprocessing import LabelEncoder\n",
+    "\n",
+    "# useful for local files, if they are likely to be changing\n",
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "from util.datamorph_example import generate_datamorph_example"
    ]
   },
   {
@@ -319,20 +325,6 @@
     "https://github.com/stefmolin/data-morph\n",
     "\n",
     "(This project is inspired by the Datasaurus Dozen, and based on the work completed in Data Morph (DOI: 10.5281/zenodo.7834197) and Same Stats, Different Graphs: Generating Datasets with Varied Appearance and Identical Statistics through Simulated Annealing by Justin Matejka and George Fitzmaurice (ACM CHI 2017))."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8b8caf3d-a646-4723-9239-b4d12c1b6b8a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# useful for local files, if they are likely to be changing\n",
-    "%load_ext autoreload\n",
-    "%autoreload 2\n",
-    "\n",
-    "from util.datamorph_example import generate_datamorph_example"
    ]
   },
   {

--- a/notebook-example/notebook-example.py
+++ b/notebook-example/notebook-example.py
@@ -56,6 +56,12 @@ from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelEncoder
 
+# useful for local files, if they are likely to be changing
+# %load_ext autoreload
+# %autoreload 2
+
+from util.datamorph_example import generate_datamorph_example
+
 # %% [markdown]
 # If you're running in Colab:
 # - open Google colab
@@ -160,13 +166,6 @@ data[data['year'] == 0]
 # https://github.com/stefmolin/data-morph
 #
 # (This project is inspired by the Datasaurus Dozen, and based on the work completed in Data Morph (DOI: 10.5281/zenodo.7834197) and Same Stats, Different Graphs: Generating Datasets with Varied Appearance and Identical Statistics through Simulated Annealing by Justin Matejka and George Fitzmaurice (ACM CHI 2017)).
-
-# %%
-# useful for local files, if they are likely to be changing
-# %load_ext autoreload
-# %autoreload 2
-
-from util.datamorph_example import generate_datamorph_example
 
 # %%
 if in_colab:


### PR DESCRIPTION
Centralising all the imports in one place to make it easier to view dependencies for the annotated example notebook